### PR TITLE
Add extension: multiGoogleTranslate

### DIFF
--- a/MultiGoogleTranslate.py
+++ b/MultiGoogleTranslate.py
@@ -1,0 +1,87 @@
+# -*- coding: utf-8 -*-
+
+"""
+Use Google Translate to translate your sentence into multiple languages. 
+Visit the following link to check available languages: 
+https://cloud.google.com/translate/docs/languages
+To add or remove languages go to: 
+'~/.config/albert/org.albert.extension.mtr/language_config.json'
+And add or remove elements based on the ISO-Codes that you found on the google documentation page.
+"""
+
+from albertv0 import *
+import json
+import urllib.request
+import urllib.parse
+import os
+
+__iid__ = "PythonInterface/v0.1"
+__prettyname__ = "Multi Google Translate"
+__version__ = "1.0"
+__trigger__ = "mtr"
+__author__ = "David Britt, Manuel Schneider"
+__dependencies__ = []
+
+ua = "Mozilla/5.0 (Windows NT 10.0; WOW64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/62.0.3202.62 Safari/537.36"
+urltmpl = "https://translate.googleapis.com/translate_a/single?client=gtx&sl=auto&tl=%s&dt=t&q=%s"
+urlbrowser = "https://translate.google.com/#auto/%s/%s"
+
+configuration_directory = os.path.expanduser("~/.config/albert/org.albert.extension.mtr")
+language_configuration_file = os.path.expanduser("~/.config/albert/org.albert.extension.mtr/language_config.json")
+
+iconPath = iconLookup('config-language')
+if not iconPath:
+    iconPath = ":python_module"
+
+if os.path.exists(language_configuration_file):
+    with open(language_configuration_file) as json_config:
+        languages = json.load(json_config)["languages"]
+else:
+    languages = ["en", "zh-CN", "hi", "es", "ru", "pt", "id", "bn", "ar", "ms", "jp", "fr", "de"]
+    try:
+        os.makedirs(configuration_directory, exist_ok=True)
+        try:
+            with open(language_configuration_file, "w") as output_file:
+                json.dump({"languages": languages}, output_file) 
+        except OSError:
+            print("There was an error opening the file: %s" % language_configuration_file)
+    except OSError:
+        print("There was an error making the directory: %s" % configuration_directory)
+
+def handleQuery(query):
+    if query.isTriggered:
+        results = []
+        item = Item(id=__prettyname__, icon=iconPath, completion=query.rawString)
+        item.text = __prettyname__
+        if len(query.string) >= 2:
+            for lang in languages:
+                try:
+                    url = urltmpl % (lang, urllib.parse.quote_plus(query.string))
+                    req = urllib.request.Request(url, headers={'User-Agent': ua})
+                    with urllib.request.urlopen(req) as response:
+                        data = json.load(response)
+                        translText = data[0][0][0]
+                        sourceText = data[2]
+                        if sourceText == lang:
+                            continue
+                        else:
+                            results.append(
+                                Item(
+                                    id=__prettyname__,
+                                    icon=iconPath,
+                                    text="%s" % (translText),
+                                    subtext="%s" % lang.upper(),
+                                    actions=[
+                                      ClipAction("Copy translation to clipboard", translText),
+                                      UrlAction("Open in your Browser", urlbrowser % (lang, query.string))
+                                    ] 
+                                )
+                            )
+                except urllib.error.URLError as urlerr:
+                    print("Connection error: %s" % urlerr)
+                    item.subtext = "Connection error."
+                    return item
+        else:
+            item.subtext = "Enter a query in the form of 'mtr <text>'. Languages {%s}" % ", ".join(languages)
+            return item
+    return results


### PR DESCRIPTION
Hi, there this is the extension that I've been prototyping for the last couple of days.
It's working pretty well, and I'm pretty sure I've managed to catch most exceptions. 

So a couple of screen shots to see  how it looks like:
When the trigger is initiated:

![image](https://user-images.githubusercontent.com/3985738/35069268-fc471ac4-fbd9-11e7-9083-06188e3c6e80.png)

The list of languages is dynamically updated based on the current language configuration.
The default list and order of languages is based on the number of speakers of each language.


This is how it looks like when a user types a query:
![image](https://user-images.githubusercontent.com/3985738/35069513-ab30f848-fbda-11e7-81f9-334fd88f30a6.png)
As you can see there are two actions namely; copy to clipboard and open in a browser.

As discussed we discussed on IRC on Tuesday I create a directory and configuration file, which is: "~/.config/albert/org.albert.extension.mtr/language_config.json"
The script creates this directory and file on the fly the first time it is initiated. 
Afterwords the user should be able to locate the file and add or remove languages as they please.
How it looks like after a user has changed the language_config.json file:
![image](https://user-images.githubusercontent.com/3985738/35070292-10a31236-fbdd-11e7-9111-9964e6d51350.png)
The only problem with this approach is that the user needs to relaunch Albert.
But it should be persistent afterwards.


Lastly when there is a connection error:
![image](https://user-images.githubusercontent.com/3985738/35069982-22b481f4-fbdc-11e7-9203-c2549d850d11.png)
This is initiated when the user starts typing a query and an exception is raised.
