### PR TITLE
Changed from Google Finance to Yahoo Search to get exchange rates

### DIFF
--- a/Currency.py
+++ b/Currency.py
@@ -25,10 +25,10 @@ def handleQuery(query):
         fields = query.string.split()
         item = Item(id=__prettyname__, icon=iconPath, completion=query.rawString)
         if len(fields) == 3:
-            url = 'https://finance.google.com/finance/converter?a=%s&from=%s&to=%s' % tuple(fields)
+            url = 'https://search.yahoo.com/search?p=%s+%s+to+%s' % tuple(fields)
             with urlopen(url) as response:
                 html = response.read().decode("latin-1")
-                m = re.search('<div id=currency_converter_result>.*<span class=bld>(\d+\.\d+).*</span>', html)
+                m = re.search('<span class=.*convert-to.*>(\d+(\.\d+)?)', html)
                 if m:
                     result = m.group(1)
                     item.text = result


### PR DESCRIPTION
Google Finance url is no longer accessible.
To avoid complexities of setting headers, I used Yahoo Search instead of Google Search to replace this feature.