### PR TITLE
GoogleTranslate & MultiGoogleTranslate: Fixed TypeError when passing HTTPResponse to json lib for decoding

### DIFF
--- a/GoogleTranslate.py
+++ b/GoogleTranslate.py
@@ -38,7 +38,7 @@ def handleQuery(query):
             url = urltmpl % (src, dst, urllib.parse.quote_plus(txt))
             req = urllib.request.Request(url, headers={'User-Agent': ua})
             with urllib.request.urlopen(req) as response:
-                data = json.load(response)
+                data = json.loads(response.read().decode('utf-8'))
                 result = data[0][0][0]
                 item.text = result
                 item.subtext = "%s-%s translation of %s" % (src.upper(), dst.upper(), txt)

--- a/MultiGoogleTranslate.py
+++ b/MultiGoogleTranslate.py
@@ -69,7 +69,11 @@ def handleQuery(query):
                     url = urltmpl % (lang, urllib.parse.quote_plus(query.string))
                     req = urllib.request.Request(url, headers={'User-Agent': ua})
                     with urllib.request.urlopen(req) as response:
-                        data = json.load(response)
+                        #print(type())
+                        #try:
+                        data = json.loads(response.read().decode("utf-8"))
+                        #except TypeError as typerr:
+                        #    print("Urgh this type.error. %s" % typerr)
                         translText = data[0][0][0]
                         sourceText = data[2]
                         if sourceText == lang:
@@ -87,7 +91,7 @@ def handleQuery(query):
                                     ]
                                 )
                             )
-                except urllib.error.URLError as urlerr:
+                except urllib.error.URLError as urlerr :
                     print("Check your internet connection: %s" % urlerr)
                     item.subtext = "Check your internet connection."
                     return item

--- a/MultiGoogleTranslate.py
+++ b/MultiGoogleTranslate.py
@@ -40,7 +40,7 @@ def initialize():
         with open(language_configuration_file) as json_config:
             languages.extend(json.load(json_config)["languages"])
     else:
-        languages.extend(["en", "zh-CN", "hi", "es", "ru", "pt", "id", "bn", "ar", "ms", "jp", "fr", "de"])
+        languages.extend(["en", "zh-CN", "hi", "es", "ru", "pt", "id", "bn", "ar", "ms", "ja", "fr", "de"])
         try:
             os.makedirs(configuration_directory, exist_ok=True)
             try:


### PR DESCRIPTION
There are 2 fixes:
1. `TypeError` when parsing response
`json.load()` raised `TypeError` when parsing responses from Google Translate. (Happened on 3.5.3)

Made change so that bytes from `response.read()` are explicitly converted to `str` and passed to `json.loads()` instead of `json.load()`.

2. Erroneous Japanese language code 
`ja` is the correct one.

Edit: Added commit fixing Japanese language code.