### PR TITLE
Coinmarketcap plugin: better price formatting

### DIFF
--- a/CoinMarketCap/__init__.py
+++ b/CoinMarketCap/__init__.py
@@ -73,7 +73,8 @@ class UpdateThread(Thread):
                     vol = coindata['24h_volume_usd']
                     vol = lformat("%d", float(vol), True) if vol else "?"
                     price = coindata['price_usd']
-                    price = lformat("%f", float(price), True) if price else "?"
+                    price_precision = "%.2f" if float(price) > 1 else "%.6f"
+                    price = lformat(price_precision, float(price), True) if price else "?"
                     if "," in price:
                         price = price.rstrip("0").rstrip(",")
                     newCoins.append(Coin(identifier=coindata['id'],


### PR DESCRIPTION
PR changes price formatting for coinmarketcap plugin by using precision based on prices. 

As we can see on [http://coinmarketcap.com](http://coinmarketcap.com), they never show BTC value as 6485,481567 - such precision is not needed for coins with price greater than $1.

Before:
![screenshot_20181022_214806](https://user-images.githubusercontent.com/482566/47305322-ee601b80-d64a-11e8-9f43-546cb81c0817.png)

After:

![screenshot_20181022_214721](https://user-images.githubusercontent.com/482566/47305312-e86a3a80-d64a-11e8-8b52-2eeb736f07fd.png)

