### PR TITLE
[Ip] Getting external IP via HTTPS instead

### DIFF
--- a/Ip.py
+++ b/Ip.py
@@ -21,7 +21,7 @@ def handleQuery(query):
     if not query.isTriggered:
         return None
 
-    with request.urlopen("http://ipecho.net/plain") as response:
+    with request.urlopen("https://ipecho.net/plain") as response:
         externalIP = response.read().decode()
 
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)


### PR DESCRIPTION
This PR proposes getting IP from `ipecho.net` via HTTPS instead of HTTP. While trivial, it can be vital in environments where a significant risk of DNS spoofing is expected.