### PR TITLE
Copyq improvements

### DIFF
--- a/CopyQ.py
+++ b/CopyQ.py
@@ -12,7 +12,7 @@ from albertv0 import *
 
 __iid__ = "PythonInterface/v0.1"
 __prettyname__ = "CopyQ"
-__version__ = "1.0"
+__version__ = "1.1"
 __trigger__ = "cq "
 __author__ = "Manuel Schneider"
 __dependencies__ = ["copyq"]

--- a/CopyQ.py
+++ b/CopyQ.py
@@ -57,7 +57,6 @@ def handleQuery(query):
     if query.isTriggered:
         try:
             pattern = re.compile(query.string, re.IGNORECASE)
-            critical(query.string)
         except re.error:
             return [
                 Item(

--- a/CopyQ.py
+++ b/CopyQ.py
@@ -93,7 +93,11 @@ def handleQuery(query):
             if not text:
                 text = "<i>No text</i>"
             else:
-                text = pattern.sub(lambda m: "<u>%s</u>" % m.group(0), html.escape(" ".join(filter(None, text.replace("\n", " ").split(" ")))))
+                U_BEGIN = "@U_BEGIN_XXXXX@"
+                U_END = "@U_END_XXXXX@"
+                raw_text = " ".join(filter(None, text.replace("\n", " ").split(" ")))
+                underlined_text = pattern.sub(lambda m: U_BEGIN + m.group(0) + U_END, raw_text)
+                text = html.escape(underlined_text).replace(U_BEGIN, "<u>").replace(U_END, "</u>")
             items.append(
                 Item(
                     id=__prettyname__,

--- a/CopyQ.py
+++ b/CopyQ.py
@@ -69,7 +69,8 @@ def handleQuery(query):
                 )
             ]
 
-        script = copyq_script_getMatches % query.string if query.string else copyq_script_getAll
+        escaped_query = query.string.replace('\\', '\\\\').replace('"', '\\"')
+        script = copyq_script_getMatches % escaped_query if query.string else copyq_script_getAll
 
         proc = subprocess.run(['copyq', '-'], input=script.encode(), stdout=subprocess.PIPE)
         json_arr = json.loads(proc.stdout.decode())

--- a/CopyQ.py
+++ b/CopyQ.py
@@ -75,6 +75,17 @@ def handleQuery(query):
         proc = subprocess.run(['copyq', '-'], input=script.encode(), stdout=subprocess.PIPE)
         json_arr = json.loads(proc.stdout.decode())
 
+        if not json_arr:
+            return [
+                Item(
+                    id=__prettyname__,
+                    icon=iconPath,
+                    text="<b>No results found.</b>",
+                    subtext="",
+                    actions=[],
+                )
+            ]
+
         items = []
         for json_obj in json_arr:
             row = json_obj['row']

--- a/CopyQ.py
+++ b/CopyQ.py
@@ -55,6 +55,19 @@ JSON.stringify(result);
 
 def handleQuery(query):
     if query.isTriggered:
+        try:
+            pattern = re.compile(query.string, re.IGNORECASE)
+            critical(query.string)
+        except re.error:
+            return [
+                Item(
+                    id=__prettyname__,
+                    icon=iconPath,
+                    text="<b>Invalid regex!</b>",
+                    subtext="",
+                    actions=[],
+                )
+            ]
 
         script = copyq_script_getMatches % query.string if query.string else copyq_script_getAll
 
@@ -62,7 +75,6 @@ def handleQuery(query):
         json_arr = json.loads(proc.stdout.decode())
 
         items = []
-        pattern = re.compile(query.string, re.IGNORECASE)
         for json_obj in json_arr:
             row = json_obj['row']
             text = json_obj['text']


### PR DESCRIPTION
For the last commit ("Properly handle escaping of underlined texts"), the problem before can be seen by copying `<foo> "bar"` and then searching for the empty string.