### PR TITLE
Simplified base converting

### DIFF
--- a/BaseConverter.py
+++ b/BaseConverter.py
@@ -55,5 +55,7 @@ def handleQuery(query):
         padding = 0 if len(fields) < 3 else fields[2]
         results = []
         for dst in sorted(base_keywords.values()):
+            if dst == src:
+                continue
             results.append(buildItem(query.rawString, src, dst, number, padding))
         return results

--- a/BaseConverter.py
+++ b/BaseConverter.py
@@ -2,10 +2,10 @@
 
 """Convert representations of numbers.
 Usage: base <src base> <dest base> <number>
-   Or: <src base name> <number>
+   Or: <src base name> <number> [padding]
 Examples: base 10 16 1234567890
           dec 1024
-          hex ff"""
+          hex 5f 8"""
 
 from albertv0 import *
 import numpy as np
@@ -19,12 +19,16 @@ __dependencies__ = ["numpy"]
 
 base_keywords = {"bin": 2, "oct": 8, "dec": 10, "hex": 16}
 
-def buildItem(completion, src, dst, number):
+def buildItem(completion, src, dst, number, padding=0):
     item = Item(id=__prettyname__, completion=completion)
     try:
         src = int(src)
         dst = int(dst)
-        item.text = np.base_repr(int(number, src), dst)
+        padding = int(padding)
+        integer = int(number, src)
+        item.text = np.base_repr(integer, dst)
+        if integer >= 0 and len(item.text) < padding:
+            item.text = '0'*(padding-len(item.text)) + item.text
         item.subtext = "Base %s representation of %s (base %s)" % (dst, number, src)
         item.addAction(ClipAction("Copy to clipboard", item.text))
     except Exception as e:
@@ -44,11 +48,12 @@ def handleQuery(query):
             return item
     else:
         fields = query.string.split()
-        if len(fields) < 1 or fields[0] not in base_keywords:
+        if len(fields) < 2 or fields[0] not in base_keywords:
             return
         src = base_keywords[fields[0]]
-        number = 0 if len(fields) < 2 else fields[1]
+        number = fields[1]
+        padding = 0 if len(fields) < 3 else fields[2]
         results = []
         for dst in sorted(base_keywords.values()):
-            results.append(buildItem(query.rawString, src, dst, number))
+            results.append(buildItem(query.rawString, src, dst, number, padding))
         return results

--- a/BaseConverter.py
+++ b/BaseConverter.py
@@ -2,36 +2,53 @@
 
 """Convert representations of numbers.
 Usage: base <src base> <dest base> <number>
-Example: base 10 16 1234567890"""
+   Or: <src base name> <number>
+Examples: base 10 16 1234567890
+          dec 1024
+          hex ff"""
 
 from albertv0 import *
 import numpy as np
 
 __iid__ = "PythonInterface/v0.1"
 __prettyname__ = "Base Converter"
-__version__ = "1.0"
+__version__ = "1.1"
 __trigger__ = "base "
 __author__ = "Manuel Schneider"
 __dependencies__ = ["numpy"]
 
+base_keywords = {"bin": 2, "oct": 8, "dec": 10, "hex": 16}
+
+def buildItem(completion, src, dst, number):
+    item = Item(id=__prettyname__, completion=completion)
+    try:
+        src = int(src)
+        dst = int(dst)
+        item.text = np.base_repr(int(number, src), dst)
+        item.subtext = "Base %s representation of %s (base %s)" % (dst, number, src)
+        item.addAction(ClipAction("Copy to clipboard", item.text))
+    except Exception as e:
+        item.text = e.__class__.__name__
+        item.subtext = str(e)
+    return item
 
 def handleQuery(query):
     if query.isTriggered:
         fields = query.string.split()
-        item = Item(id=__prettyname__, completion=query.rawString)
         if len(fields) == 3:
-            try:
-                src = int(fields[0])
-                dst = int(fields[1])
-                number = fields[2]
-                item.text = np.base_repr(int(number, src), dst)
-                item.subtext = "Base %s representation of %s (base %s)" % (dst, number, src)
-                item.addAction(ClipAction("Copy to clipboard", item.text))
-            except Exception as e:
-                item.text = e.__class__.__name__
-                item.subtext = str(e)
-            return item
+            return buildItem(query.rawString, fields[0], fields[1], fields[2])
         else:
+            item = Item(id=__prettyname__, completion=query.rawString)
             item.text = __prettyname__
             item.subtext = "Enter a query in the form of \"&lt;srcbase&gt; &lt;dstbase&gt; &lt;number&gt;\""
             return item
+    else:
+        fields = query.string.split()
+        if len(fields) < 1 or fields[0] not in base_keywords:
+            return
+        src = base_keywords[fields[0]]
+        number = 0 if len(fields) < 2 else fields[1]
+        results = []
+        for dst in sorted(base_keywords.values()):
+            results.append(buildItem(query.rawString, src, dst, number))
+        return results


### PR DESCRIPTION
I've added 4 commands for frequently used number base (2/8/10/16).
Command usage is `<src base> <number> [padding]`.
Albert shows other three representations of given number while typing.

![image](https://user-images.githubusercontent.com/2733275/50347579-f831cc80-0570-11e9-8ad2-66eb3f40b013.png)

The optional padding arguments can be used to pad output to n-digits (at least).