### PR TITLE
More fuzzy matching and matching multiple words for window switcher

### DIFF
--- a/window_switcher.py
+++ b/window_switcher.py
@@ -14,20 +14,23 @@ Window = namedtuple("Window", ["wid", "desktop", "wm_class", "host", "wm_name"])
 
 __iid__ = "PythonInterface/v0.1"
 __prettyname__ = "Window Switcher"
-__version__ = "1.4"
+__version__ = "1.5"
 __author__ = "Ed Perez, Manuel Schneider"
 __dependencies__ = ["wmctrl"]
 
 if which("wmctrl") is None:
     raise Exception("'wmctrl' is not in $PATH.")
 
+def matchWindow(win, text):
+    return (text in win.wm_class.lower() or text in win.wm_name.lower())
+
 def handleQuery(query):
-    stripped = query.string.strip().lower()
+    stripped = query.string.strip().lower().split()
     if stripped:
         results = []
         for line in subprocess.check_output(['wmctrl', '-l', '-x']).splitlines():
             win = Window(*[token.decode() for token in line.split(None,4)])
-            if win.desktop != "-1"  and stripped in win.wm_class.split('.')[0].lower():
+            if win.desktop != "-1" and all(matchWindow(win, text) for text in stripped):
                 results.append(Item(id="%s%s" % (__prettyname__, win.wm_class),
                                     icon=iconLookup(win.wm_class.split('.')[0]),
                                     text="%s  - <i>Desktop %s</i>" % (win.wm_class.split('.')[-1].replace('-',' '), win.desktop),

--- a/window_switcher.py
+++ b/window_switcher.py
@@ -27,7 +27,7 @@ def notSticky(win):
 
 
 def matchesQuery(win, text):
-    keywords = text.lower().split()
+    keywords = filter(None, text.lower().split())
     return all(keyword in win.wm_class.lower() or keyword in win.wm_name.lower() for keyword in keywords)
 
 

--- a/window_switcher.py
+++ b/window_switcher.py
@@ -21,16 +21,23 @@ __dependencies__ = ["wmctrl"]
 if which("wmctrl") is None:
     raise Exception("'wmctrl' is not in $PATH.")
 
-def matchWindow(win, text):
-    return (text in win.wm_class.lower() or text in win.wm_name.lower())
+
+def notSticky(win):
+    return win.desktop != "-1"
+
+
+def matchesQuery(win, text):
+    keywords = text.lower().split()
+    return all(keyword in win.wm_class.lower() or keyword in win.wm_name.lower() for keyword in keywords)
+
 
 def handleQuery(query):
-    stripped = query.string.strip().lower().split()
-    if stripped:
+    strippedQuery = query.string.strip()
+    if strippedQuery:
         results = []
         for line in subprocess.check_output(['wmctrl', '-l', '-x']).splitlines():
             win = Window(*[token.decode() for token in line.split(None,4)])
-            if win.desktop != "-1" and all(matchWindow(win, text) for text in stripped):
+            if notSticky(win) and matchesQuery(win, strippedQuery):
                 results.append(Item(id="%s%s" % (__prettyname__, win.wm_class),
                                     icon=iconLookup(win.wm_class.split('.')[0]),
                                     text="%s  - <i>Desktop %s</i>" % (win.wm_class.split('.')[-1].replace('-',' '), win.desktop),

--- a/window_switcher.py
+++ b/window_switcher.py
@@ -15,7 +15,7 @@ Window = namedtuple("Window", ["wid", "desktop", "wm_class", "host", "wm_name"])
 __iid__ = "PythonInterface/v0.1"
 __prettyname__ = "Window Switcher"
 __version__ = "1.5"
-__author__ = "Ed Perez, Manuel Schneider"
+__author__ = "Ed Perez, Manuel Schneider, Hugo Valk"
 __dependencies__ = ["wmctrl"]
 
 if which("wmctrl") is None:


### PR DESCRIPTION
The Window Switcher plugin is quite useful to me, but I had trouble matching some of the windows on my desktop. This happens because the wm_class is not always descriptive enough. For example:

- All Java apps have a wm_class that starts with: `sun-awt-X11-XFramePeer.`. 
- Also sometimes the first segment of the wm_class is something generic, like for example `main.terminology` for the Terminology terminal app. 

In all those cases, the 'nice' application name can be found after the dot in wm_class or in the wm_name field.

This change matches all words in the query (splitted on whitespace) with wm_class OR wm_name. This enables me switch to all windows on my screen. Also, it allows switching to the right IntelliJ project, since the project name happens to be in the wm_name. 
I have tested this change on Arch Linux with KDE and Ubuntu 18.04 with Gnome. 