### PR TITLE
Fix installation command

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository is shipped with albert. If you want to have bleeding edge extens
 To install the extensions in user space type the following in your terminal:
 
 ```
-git clone https://github.com/albertlauncher/python.git "~/.local/share/albert/org.albert.extension.python/modules"
+git clone https://github.com/albertlauncher/python.git ~/.local/share/albert/org.albert.extension.python/modules
 ```
 
 If you send a PR I'll invite you to the reviewers team (if I don't forget it), I'd appreciate if you could review others contributions.


### PR DESCRIPTION
The tilde `~` in double-quotes are not going to be expanded ([Double-Quotes](http://pubs.opengroup.org/onlinepubs/009604599/utilities/xcu_chap02.html#tag_02_02_03)). It causes the repository to be cloned inside a subdirectory named `~` instead of the home directory.