### PR TITLE
Fixed icon of Dango Emoji extension

### DIFF
--- a/dango_emoji/__init__.py
+++ b/dango_emoji/__init__.py
@@ -24,7 +24,7 @@ __trigger__ = ":"
 __author__ = "David Britt"
 __dependencies__ = []
 
-icon_path = "%s/%s.png" % (os.path.dirname(__file__), __name__)
+icon_path = os.path.dirname(__file__) + "/dangoemoji.png"
 dangoUrl = "https://emoji.getdango.com/api/emoji"
 emojipedia_url = "https://emojipedia.org/%s"
 


### PR DESCRIPTION
Explicitly specify the file name, just like how it's done in Dango Kao extension.
Previously the resulting file name would `albert.dango_emoji.png`, which was obviously wrong.