### PR TITLE
improve gnu units output parsing

### DIFF
--- a/units.py
+++ b/units.py
@@ -30,39 +30,50 @@ if not icon:
     icon = ":python_module"
 
 regex = re.compile(r"(\S+)(?:\s+to)\s+(\S+)")
+unitListOutput = re.compile(r"(\d+;)+[\d.]+")
 
-def stripPrefix(text, prefix):
-    if text.startswith(prefix):
-        return text[len(prefix):]
-    return text
+
+def getUnitsResult(args):
+    command = ['units', '--terse', '--'] + list(args)
+    query = "units -t -- %s" % ' '.join(args)
+    try:
+        output = sp.check_output(command, stderr=sp.STDOUT).decode().strip()
+
+        # usually we want terse output, but when we get a unit-list output
+        # it looks like this 1;124;18;11;14.025322 which is not friendly
+        # so we're falling back to not quite terse output
+        if unitListOutput.fullmatch(output):
+            command = ['units', '--strict', '--one-line', '--quiet', '--'] + list(args)
+            query = "units -s1q -- %s" % ' '.join(args)
+            output = sp.check_output(command, stderr=sp.STDOUT).decode().strip()
+
+        return (output, query, True)
+    except sp.CalledProcessError as e:
+        return (e.stdout.decode().strip().splitlines()[0], query, False)
+
 
 def handleQuery(query):
-
     if query.isTriggered:
         args = query.string.split()
         item = Item(id='python.gnu_units', icon=icon, completion=query.rawString)
         if args:
-            try:
-                output = sp.check_output(['units', '--strict', '--one-line', '--quiet'] + query.string.split(), stderr=sp.STDOUT).decode()
-                item.text = stripPrefix(stripPrefix(output.strip(), "Definition: "), "* ")
-                item.addAction(ClipAction("Copy to clipboard", item.text))
-            except sp.CalledProcessError as e:
-                item.text = e.stdout.decode().strip().partition('\n')[0]
-            item.subtext = "Result of 'units %s'" % query.string
+            result, command, success = getUnitsResult(args)
+            item.text = result
+            item.subtext = "Result of '%s'" % command
+            item.addAction(ClipAction("Copy to clipboard", item.text))
         else:
             item.text = "Empty input"
-            item.subtext = "Enter something to convert"
+            item.subtext = "Enter a query of the form <from> [<to>]"
         return item
-
     else:
         match = regex.fullmatch(query.string.strip())
         if match:
             args = match.group(1, 2)
-            try:
-                item = Item(id='python.gnu_units', icon=icon, completion=query.rawString)
-                item.text = sp.check_output(['units', '-t'] + list(args)).decode().strip()
-                item.subtext = "Result of 'units -t %s %s'" % args
-                item.addAction(ClipAction("Copy to clipboard", item.text))
-                return item
-            except sp.CalledProcessError as e:
-                pass
+            result, command, success = getUnitsResult(args)
+            if not success:
+                return
+            item = Item(id='python.gnu_units', icon=icon, completion=query.rawString)
+            item.text = result
+            item.subtext = "Result of '%s'" % command
+            item.addAction(ClipAction("Copy to clipboard", item.text))
+            return item

--- a/units.py
+++ b/units.py
@@ -48,7 +48,7 @@ def handleQuery(query):
                 item.addAction(ClipAction("Copy to clipboard", item.text))
             except sp.CalledProcessError as e:
                 item.text = e.stdout.decode().strip().partition('\n')[0]
-            item.subtext = "Result of 'units -t %s'" % query.string
+            item.subtext = "Result of 'units %s'" % query.string
         else:
             item.text = "Empty input"
             item.subtext = "Enter something to convert"

--- a/units.py
+++ b/units.py
@@ -31,6 +31,11 @@ if not icon:
 
 regex = re.compile(r"(\S+)(?:\s+to)\s+(\S+)")
 
+def stripPrefix(text, prefix):
+    if text.startswith(prefix):
+        return text[len(prefix):]
+    return text
+
 def handleQuery(query):
 
     if query.isTriggered:
@@ -38,7 +43,8 @@ def handleQuery(query):
         item = Item(id='python.gnu_units', icon=icon, completion=query.rawString)
         if args:
             try:
-                item.text = sp.check_output(['units', '-t'] + query.string.split(), stderr=sp.STDOUT).decode().strip()
+                output = sp.check_output(['units', '--strict', '--one-line', '--quiet'] + query.string.split(), stderr=sp.STDOUT).decode()
+                item.text = stripPrefix(stripPrefix(output.strip(), "Definition: "), "* ")
                 item.addAction(ClipAction("Copy to clipboard", item.text))
             except sp.CalledProcessError as e:
                 item.text = e.stdout.decode().strip().partition('\n')[0]


### PR DESCRIPTION
`units 500seconds time` is currently giving output like this `0;0;0;8;20` which is not very human friendly
this PR changes the output to `8 min + 20 sec`

i believe the other outputs are unchanged:
`units 5min` => `300 s`
`units 1foot cm` => `30.48`

also, giving negative inputs is now supported, as units interpreted them as flags before