### PR TITLE
Window Switcher improvements

### DIFF
--- a/window_switcher.py
+++ b/window_switcher.py
@@ -38,8 +38,12 @@ def handleQuery(query):
             ]
 
             if any(stripped in match for match in matches):
+                iconPath = iconLookup(win_instance)
+                if iconPath == "":
+                    iconPath = iconLookup(win_class.lower())
+
                 results.append(Item(id="%s%s" % (__prettyname__, win.wm_class),
-                                    icon=iconLookup(win_instance),
+                                    icon=iconPath,
                                     text="%s  - <i>Desktop %s</i>" % (win.wm_class.split('.')[-1].replace('-',' '), win.desktop),
                                     subtext=win.wm_name,
                                     actions=[ProcAction("Switch Window",

--- a/window_switcher.py
+++ b/window_switcher.py
@@ -27,9 +27,19 @@ def handleQuery(query):
         results = []
         for line in subprocess.check_output(['wmctrl', '-l', '-x']).splitlines():
             win = Window(*[token.decode() for token in line.split(None,4)])
-            if win.desktop != "-1"  and stripped in win.wm_class.split('.')[0].lower():
+            if win.desktop == "-1":
+                continue
+
+            win_instance, win_class = win.wm_class.split('.')
+            matches = [
+                win_instance.lower(),
+                win_class.lower(),
+                win.wm_name.lower()
+            ]
+
+            if any(stripped in match for match in matches):
                 results.append(Item(id="%s%s" % (__prettyname__, win.wm_class),
-                                    icon=iconLookup(win.wm_class.split('.')[0]),
+                                    icon=iconLookup(win_instance),
                                     text="%s  - <i>Desktop %s</i>" % (win.wm_class.split('.')[-1].replace('-',' '), win.desktop),
                                     subtext=win.wm_name,
                                     actions=[ProcAction("Switch Window",


### PR DESCRIPTION
# Summary

Currently the window switcher extension will only filter by the window's *instance* (the first part of `WM_CLASS`) which makes it difficult to find a specific window when you have many instances of an application open (eg browsers or terminals). This PR updates it to filter on *both* parts, while also including the window title to make it even more useful.

---

## Bug Fixes

#### Unable to List Firefox Windows
The reason for this PR - Firefox's `WM_CLASS` is `Navigator.Firefox` so the extension couldn't find any Firefox windows if you typed in "firefox" - instead you'd have to type "navigator".

There were a couple other small yet (IMHO) important bugs so I took the liberty of fixing those too. Each of the 3 commits relies on the previous one, but if you'd prefer them in separate PRs let me know.

#### Missing Firefox (and possibly other) Icons

Because of its unusual `WM_CLASS`, icons for Firefox results weren't being found. Its icon is called "firefox" (lowercase), so this is fixed by falling back to `win_class.lower()` if `iconLookup(win_instance)` fails.

#### Broken Output for Windows with Spaces
Firefox Developer Edition has spaces in its `WM_CLASS` which was breaking the output (see last result in "before" screenshot below) due to the way the lines of `wmctrl` output were being split. To fix this we add extra parsing to make sure the `Window` tuple doesn't get messed up, then replace spaces with dashes when preparing the list of matches, which also fixes its icon.

The output bug also affected Virtualbox (with a `WM_CLASS` of `VirtualBox Manager.VirtualBox Manager`), although Virtualbox icons still aren't found because its class differs from the icon name. To really fix it we'd need to find/parse the `.desktop` files... That's probably asking a bit *too* much for one PR :wink:

---

## Screenshots
### Before
![albert-win-pr-before](https://user-images.githubusercontent.com/1521802/60243357-f47c5b00-98af-11e9-8589-38fe4a10908c.png)
> ^ Notice the last item is actually Firefox Developer Edition, but it's detected as Firefox

### After
![albert-win-pr-after](https://user-images.githubusercontent.com/1521802/60243355-f47c5b00-98af-11e9-936b-0ac0e1af8cd6.png)