### PR TITLE
Add 'notify-send'.

### DIFF
--- a/timer/__init__.py
+++ b/timer/__init__.py
@@ -33,6 +33,8 @@ class AlbertTimer(Timer):
 
         def timeout():
             subprocess.Popen(["aplay", soundPath])
+            subprocess.Popen(["notify-send", "-i", iconPath,
+                              "\"Your %ss timer is up\"" % self.interval])
             global timers
             timers.remove(self)
 


### PR DESCRIPTION
Hi.

I thought that adding notify-send to the timer module in the Python plugin will make things a little better than just playing the sound. I've tested only on Linux Fedora 30, in Gnome.

Thanks,
Tomas