### PR TITLE
Add xkcd plugin as submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "xkcd"]
+	path = xkcd
+	url = https://github.com/bergercookie/xkcd-albert-plugin


### PR DESCRIPTION
Hi there,

I've made a plugin for looking up xkcd comics.
You can find the plugin here: https://github.com/bergercookie/xkcd-albert-plugin

This is a PR for adding it as a submodule to the python plugins but if you prefer a different way of adding it just let me know.

Feel free to give me any feedback on the actual implementation.

Regards,
Nikos