### PR TITLE
fix: currency converter round float returns value times 10

### DIFF
--- a/currency_converter.py
+++ b/currency_converter.py
@@ -58,7 +58,7 @@ class Yahoo:
         self.name = "Yahoo"
 
     def convert(self, amount, src, dst):
-        url = 'https://search.yahoo.com/search?p=%s+%s+to+%s' % (amount, src, dst)
+        url = 'https://search.yahoo.com/search?p=%.2f+%s+to+%s' % (float(amount), src, dst)
         with urlopen(url) as response:
             html = response.read().decode()
             m = re.search('<span class=.*convert-to.*>(\d+(\.\d+)?)', html)


### PR DESCRIPTION
When querying for a rounded amount like "400 usd to ars", the value
passed for the yahoo query comes through as 400.0, which is in turn
interpreted by the yahoo search api as 4000.
Added formating and conversion on the api query string generation
for passing 2 decimal places.