### PR TITLE
Define path and binary for RubyMine

### DIFF
--- a/jetbrains_projects/__init__.py
+++ b/jetbrains_projects/__init__.py
@@ -26,6 +26,7 @@ paths = [  # <Name for config directory>, <possible names for the binary/icon>
      "intellij-idea-ue-bundled-jre intellij-idea-ultimate-edition idea-ce-eap idea-ue-eap idea idea-ultimate"],
     ["PhpStorm", "phpstorm"],
     ["PyCharm", "pycharm pycharm-eap charm"],
+    ["RubyMine", "rubymine"],
     ["WebStorm", "webstorm"],
 ]
 


### PR DESCRIPTION
RubyMine is another IDE from JetBrains that has the same structure as other IntelliJ based products. So just adding the path for it will make ruby projects appear in the launcher.

For example:
![image](https://user-images.githubusercontent.com/1056502/69350136-449df480-0c79-11ea-98f8-63f491660d2d.png)
