### PR TITLE
Fix key errors in youtube plugin

### DIFF
--- a/youtube.py
+++ b/youtube.py
@@ -51,6 +51,7 @@ def handleQuery(query):
                         try:
                             if type == 'videoRenderer':
                                 id = data['videoId']
+                                text = data['title']['runs'][0]['text']
                                 subtext = 'Video'
                                 if 'lengthText' in data:
                                     subtext = subtext + " | %s" % data['lengthText']['simpleText'].strip()
@@ -61,6 +62,7 @@ def handleQuery(query):
                                 actions=[ UrlAction('Watch on Youtube', 'https://youtube.com/watch?v=%s' % id) ]
                             elif type == 'channelRenderer':
                                 id = data['channelId']
+                                text = data['title']['simpleText']
                                 subtext = 'Channel'
                                 if 'videoCountText' in data:
                                     subtext = subtext + " | %s" % data['videoCountText']['simpleText'].strip()
@@ -75,7 +77,7 @@ def handleQuery(query):
 
                         item = Item(id=__prettyname__,
                                     icon=data['thumbnail']['thumbnails'][0]['url'].split('?', 1)[0] if data['thumbnail']['thumbnails'] else __icon__,
-                                    text=data['title']['simpleText'],
+                                    text=text,
                                     subtext=subtext,
                                     completion=query.rawString,
                                     actions=actions

--- a/youtube.py
+++ b/youtube.py
@@ -65,7 +65,7 @@ def handleQuery(query):
                                 text = data['title']['simpleText']
                                 subtext = 'Channel'
                                 if 'videoCountText' in data:
-                                    subtext = subtext + " | %s" % data['videoCountText']['simpleText'].strip()
+                                    subtext = subtext + " | %s videos" % data['videoCountText']['runs'][0]['text'].strip()
                                 if 'subscriberCountText' in data:
                                     subtext = subtext + " | %s" % data['subscriberCountText']['simpleText'].strip()
                                 actions=[ UrlAction('Show on Youtube', 'https://www.youtube.com/channel/%s' % id) ]

--- a/youtube.py
+++ b/youtube.py
@@ -11,7 +11,7 @@ from os import path
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
-from albertv0 import Item, UrlAction, iconLookup
+from albertv0 import Item, UrlAction, iconLookup, critical
 
 __iid__ = 'PythonInterface/v0.1'
 __prettyname__ = 'Youtube'
@@ -51,7 +51,6 @@ def handleQuery(query):
                         try:
                             if type == 'videoRenderer':
                                 id = data['videoId']
-                                text = data['title']['runs'][0]['text']
                                 subtext = 'Video'
                                 if 'lengthText' in data:
                                     subtext = subtext + " | %s" % data['lengthText']['simpleText'].strip()
@@ -62,10 +61,9 @@ def handleQuery(query):
                                 actions=[ UrlAction('Watch on Youtube', 'https://youtube.com/watch?v=%s' % id) ]
                             elif type == 'channelRenderer':
                                 id = data['channelId']
-                                text = data['title']['simpleText']
                                 subtext = 'Channel'
                                 if 'videoCountText' in data:
-                                    subtext = subtext + " | %s videos" % data['videoCountText']['runs'][0]['text'].strip()
+                                    subtext = subtext + " | %s" % textFrom(data['videoCountText'])
                                 if 'subscriberCountText' in data:
                                     subtext = subtext + " | %s" % data['subscriberCountText']['simpleText'].strip()
                                 actions=[ UrlAction('Show on Youtube', 'https://www.youtube.com/channel/%s' % id) ]
@@ -77,10 +75,16 @@ def handleQuery(query):
 
                         item = Item(id=__prettyname__,
                                     icon=data['thumbnail']['thumbnails'][0]['url'].split('?', 1)[0] if data['thumbnail']['thumbnails'] else __icon__,
-                                    text=text,
+                                    text=textFrom(data['title']),
                                     subtext=subtext,
                                     completion=query.rawString,
                                     actions=actions
                                 )
                         items.append(item)
                 return items
+
+def textFrom(val):
+    text = val['simpleText'] if 'runs' not in val else \
+        ''.join('{}'.format(v['text']) for v in val['runs'])
+
+    return text.strip()

--- a/youtube.py
+++ b/youtube.py
@@ -11,7 +11,7 @@ from os import path
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
-from albertv0 import Item, UrlAction, iconLookup, critical
+from albertv0 import Item, UrlAction, iconLookup, critical, info
 
 __iid__ = 'PythonInterface/v0.1'
 __prettyname__ = 'Youtube'
@@ -37,57 +37,76 @@ def handleQuery(query):
         if not query.isValid:
             return
 
+        info("Searching YouTube for '{}'".format(query.string))
         req = Request(headers=HEADERS, url='https://www.youtube.com/results?{}'.format(
             urlencode({ 'search_query': query.string.strip() })))
 
         with urlopen(req) as response:
-            match = re.search(re_videos, response.read().decode())
-            if match:
-                results = json.loads(match.group(1))
-                results = results['contents']['twoColumnSearchResultsRenderer']['primaryContents']['sectionListRenderer']['contents'][0]['itemSectionRenderer']['contents']
-                items = []
-                for result in results:
-                    for type, data in result.items():
-                        try:
-                            if type == 'videoRenderer':
-                                subtext = ['Video']
-                                action = 'Watch on Youtube'
-                                link = 'watch?v={}'.format(data['videoId'])
+            responseBytes = response.read()
+            match = re.search(re_videos, responseBytes.decode())
+            if match is None:
+                critical("Failed to receive expected data from YouTube. This likely means API changes, but could just be a failed request.")
+                logHtml(responseBytes)
+                return
 
-                                if 'lengthText' in data:
-                                    subtext.append(textFrom(data['lengthText']))
-                                if 'shortViewCountText' in data:
-                                    subtext.append(textFrom(data['shortViewCountText']))
-                                if 'publishedTimeText' in data:
-                                    subtext.append(textFrom(data['publishedTimeText']))
+            results = json.loads(match.group(1))
+            results = results['contents']['twoColumnSearchResultsRenderer']['primaryContents']['sectionListRenderer']['contents'][0]['itemSectionRenderer']['contents']
+            items = []
+            for result in results:
+                for type, data in result.items():
+                    try:
+                        if type == 'videoRenderer':
+                            subtext = ['Video']
+                            action = 'Watch on Youtube'
+                            link = 'watch?v={}'.format(data['videoId'])
 
-                            elif type == 'channelRenderer':
-                                subtext = ['Channel']
-                                action = 'Show on Youtube'
-                                link = 'channel/{}'.format(data['channelId'])
+                            if 'lengthText' in data:
+                                subtext.append(textFrom(data['lengthText']))
+                            if 'shortViewCountText' in data:
+                                subtext.append(textFrom(data['shortViewCountText']))
+                            if 'publishedTimeText' in data:
+                                subtext.append(textFrom(data['publishedTimeText']))
 
-                                if 'videoCountText' in data:
-                                    subtext.append(textFrom(data['videoCountText']))
-                                if 'subscriberCountText' in data:
-                                    subtext.append(textFrom(data['subscriberCountText']))
-                            else:
-                                continue
-                        except Exception as e:
-                            critical(e)
-                            critical(json.dumps(result, indent=4))
+                        elif type == 'channelRenderer':
+                            subtext = ['Channel']
+                            action = 'Show on Youtube'
+                            link = 'channel/{}'.format(data['channelId'])
 
-                        item = Item(id=__prettyname__,
-                                    icon=data['thumbnail']['thumbnails'][0]['url'].split('?', 1)[0] if data['thumbnail']['thumbnails'] else __icon__,
-                                    text=textFrom(data['title']),
-                                    subtext=' | '.join(subtext),
-                                    completion=query.rawString,
-                                    actions=[ UrlAction(action, 'https://www.youtube.com/' + link) ]
-                                )
-                        items.append(item)
-                return items
+                            if 'videoCountText' in data:
+                                subtext.append(textFrom(data['videoCountText']))
+                            if 'subscriberCountText' in data:
+                                subtext.append(textFrom(data['subscriberCountText']))
+                        else:
+                            continue
+                    except Exception as e:
+                        critical(e)
+                        critical(json.dumps(result, indent=4))
+
+                    item = Item(id=__prettyname__,
+                                icon=data['thumbnail']['thumbnails'][0]['url'].split('?', 1)[0] if data['thumbnail']['thumbnails'] else __icon__,
+                                text=textFrom(data['title']),
+                                subtext=' | '.join(subtext),
+                                completion=query.rawString,
+                                actions=[ UrlAction(action, 'https://www.youtube.com/' + link) ]
+                            )
+                    items.append(item)
+            return items
 
 def textFrom(val):
     text = val['simpleText'] if 'runs' not in val else \
         ''.join('{}'.format(v['text']) for v in val['runs'])
 
     return text.strip()
+
+def logHtml(html):
+    logTime = time.strftime("%Y%m%d-%H%M%S")
+    logName = 'albert.plugins.youtube_dump'
+    logPath = '/tmp/{}-{}.html'.format(logName, logTime)
+
+    f = open(logPath, 'wb')
+    f.write(html)
+    f.close()
+
+    critical("The HTML output has been dumped to {}.".format(logPath))
+    critical("If the page looks ok in a browser, please include the dump in a new issue:")
+    critical("  https://www.github.com/albertlauncher/albert/issues/new")


### PR DESCRIPTION
Resolves an issue reported by Laurent Meyer in the telegram chat, caused by a change in the data structure used on Youtube.

Previous data:
```json
{ "simpleText": "3 videos" }
```

Current data:
```json
{ "runs": [
  { "text": "3" },
  { "text": " videos" }
]}
```

It would seem that values are gradually being switched as many still use the `simpleText` key, so to help future-proof things slightly, all values are updated to use a helper function that autodetects either `runs` or `simpleText`.