### PR TITLE
Fix #917

### DIFF
--- a/currency_converter.py
+++ b/currency_converter.py
@@ -58,6 +58,8 @@ class Yahoo:
         self.name = "Yahoo"
 
     def convert(self, amount, src, dst):
+        if amount.is_integer:
+            amount = int(amount)
         url = 'https://search.yahoo.com/search?p=%s+%s+to+%s' % (amount, src, dst)
         with urlopen(url) as response:
             html = response.read().decode()


### PR DESCRIPTION
Yahoo search apparently parses "500.0" as 5000 which results in an inaccurate conversion as the module parses amount as float by default.