### PR TITLE
[timer plugin] add optional timer names

### DIFF
--- a/timer/__init__.py
+++ b/timer/__init__.py
@@ -105,9 +105,10 @@ def handleQuery(query):
                 h, m = divmod(m, 60)
                 identifier = "%d:%02d:%02d" % (h, m, s)
 
+                timer_name_with_quotes = f'"{timer.name}"' if timer.name else ''
                 items.append(Item(
                     id=__prettyname__,
-                    text=f'Delete timer <i>"{timer.name}" [{identifier}]</i>',
+                    text=f'Delete timer <i>{timer_name_with_quotes} [{identifier}]</i>',
                     subtext="Times out %s" % strftime("%X", localtime(timer.end)),
                     icon=iconPath,
                     completion=query.rawString,

--- a/timer/__init__.py
+++ b/timer/__init__.py
@@ -108,5 +108,14 @@ def handleQuery(query):
                     completion=query.rawString,
                     actions=[FuncAction("Delete timer", lambda timer=timer: deleteTimer(timer))]
                 ))
+            if items:
+                return items
+            # Display hint item
+            return Item(
+                id=__prettyname__,
+                text="Add timer",
+                subtext=f"Enter a query in the form of '{__trigger__}[[hours:]minutes:] [name]'",
+                icon=iconPath,
+                completion=query.rawString
+            )
 
-            return items

--- a/timer/__init__.py
+++ b/timer/__init__.py
@@ -35,6 +35,11 @@ class AlbertTimer(Timer):
             subprocess.Popen(["aplay", soundPath])
             global timers
             timers.remove(self)
+            subtext="Timed out at %s" % strftime("%X", localtime(self.end))
+            if self.name:
+                subprocess.Popen(['notify-send', f'Timer "{self.name}"', '-u', 'critical', subtext])
+            else:
+                subprocess.Popen(['notify-send', 'Timer', '-u', 'critical', subtext])
 
         super().__init__(interval=interval, function=timeout)
         self.interval = interval

--- a/timer/__init__.py
+++ b/timer/__init__.py
@@ -77,7 +77,7 @@ def handleQuery(query):
                 return Item(
                     id=__prettyname__,
                     text="Invalid input",
-                    subtext=f"Enter a query in the form of '{__trigger__}[[hours:]minutes:] [name]'",
+                    subtext=f"Enter a query in the form of '{__trigger__}[[hours:]minutes:]seconds [name]'",
                     icon=iconPath,
                     completion=query.rawString
                 )
@@ -119,7 +119,7 @@ def handleQuery(query):
             return Item(
                 id=__prettyname__,
                 text="Add timer",
-                subtext=f"Enter a query in the form of '{__trigger__}[[hours:]minutes:] [name]'",
+                subtext=f"Enter a query in the form of '{__trigger__}[[hours:]minutes:]seconds [name]'",
                 icon=iconPath,
                 completion=query.rawString
             )

--- a/timer/__init__.py
+++ b/timer/__init__.py
@@ -37,9 +37,9 @@ class AlbertTimer(Timer):
             timers.remove(self)
             subtext="Timed out at %s" % strftime("%X", localtime(self.end))
             if self.name:
-                subprocess.Popen(['notify-send', f'Timer "{self.name}"', '-u', 'critical', subtext])
+                subprocess.Popen(['notify-send', f'Timer "{self.name}"', '-t', '0', subtext])
             else:
-                subprocess.Popen(['notify-send', 'Timer', '-u', 'critical', subtext])
+                subprocess.Popen(['notify-send', 'Timer', '-t', '0', subtext])
 
         super().__init__(interval=interval, function=timeout)
         self.interval = interval

--- a/timer/__init__.py
+++ b/timer/__init__.py
@@ -37,7 +37,7 @@ class AlbertTimer(Timer):
             timers.remove(self)
             subtext="Timed out at %s" % strftime("%X", localtime(self.end))
             if self.name:
-                subprocess.Popen(['notify-send', f'Timer "{self.name}"', '-t', '0', subtext])
+                subprocess.Popen(['notify-send', 'Timer "%s"' % self.name, '-t', '0', subtext])
             else:
                 subprocess.Popen(['notify-send', 'Timer', '-t', '0', subtext])
 
@@ -77,7 +77,7 @@ def handleQuery(query):
                 return Item(
                     id=__prettyname__,
                     text="Invalid input",
-                    subtext=f"Enter a query in the form of '{__trigger__}[[hours:]minutes:]seconds [name]'",
+                    subtext="Enter a query in the form of '%s[[hours:]minutes:]seconds [name]'" % __trigger__,
                     icon=iconPath,
                     completion=query.rawString
                 )
@@ -90,7 +90,7 @@ def handleQuery(query):
             return Item(
                 id=__prettyname__,
                 text=formatSeconds(seconds),
-                subtext=f'Set a timer with name "{name}"' if name else 'Set a timer',
+                subtext='Set a timer with name "%s"' % name if name else 'Set a timer',
                 icon=iconPath,
                 completion=query.rawString,
                 actions=[FuncAction("Set timer", lambda sec=seconds: startTimer(sec, name))]
@@ -105,10 +105,10 @@ def handleQuery(query):
                 h, m = divmod(m, 60)
                 identifier = "%d:%02d:%02d" % (h, m, s)
 
-                timer_name_with_quotes = f'"{timer.name}"' if timer.name else ''
+                timer_name_with_quotes = '"%s"' % timer.name if timer.name else ''
                 items.append(Item(
                     id=__prettyname__,
-                    text=f'Delete timer <i>{timer_name_with_quotes} [{identifier}]</i>',
+                    text='Delete timer <i>%s [%s]</i>' % (timer_name_with_quotes, identifier),
                     subtext="Times out %s" % strftime("%X", localtime(timer.end)),
                     icon=iconPath,
                     completion=query.rawString,
@@ -120,7 +120,7 @@ def handleQuery(query):
             return Item(
                 id=__prettyname__,
                 text="Add timer",
-                subtext=f"Enter a query in the form of '{__trigger__}[[hours:]minutes:]seconds [name]'",
+                subtext="Enter a query in the form of '%s[[hours:]minutes:]seconds [name]'" % __trigger__,
                 icon=iconPath,
                 completion=query.rawString
             )


### PR DESCRIPTION
This PR has the following changes:
* main change is that timers can have an optional name
* notify-send is used to notify about timeouts
* display a "hint item" when the query "timer " is inserted and no timers are active

I consider the "name" feature useful for long running timers.

I am not sure if the change with `notify-send` is suitable for the general public because the notification never times out. But for my use-case this is what I want..