### PR TITLE
Disable albert sorting for copyq

### DIFF
--- a/copyq/__init__.py
+++ b/copyq/__init__.py
@@ -67,6 +67,7 @@ def copyq_get_all():
 
 def handleQuery(query):
     if query.isTriggered:
+        query.disableSort()
 
         items = []
         pattern = re.compile(query.string, re.IGNORECASE)


### PR DESCRIPTION
Albert sorting should be disabled for copyq plugin.