### PR TITLE
Update __init__.py

### DIFF
--- a/bitwarden/__init__.py
+++ b/bitwarden/__init__.py
@@ -12,7 +12,7 @@ __title__ = "Bitwarden"
 __version__ = "0.4.0"
 __triggers__ = "bw "
 __authors__ = "Asger Hautop Drewsen"
-__exec_deps__ = ["rbw"]
+__exec_deps__ = ["rbw", "xclip"]
 
 ICON_PATH = iconLookup("dialog-password")
 


### PR DESCRIPTION
The current copy action does not use the standard implementation. It uses xclip, which is fine, but then it should be added as a depedency. So that users know they need to install it.