### PR TITLE
gracefully handle malformed WM_CLASS

### DIFF
--- a/window_switcher/__init__.py
+++ b/window_switcher/__init__.py
@@ -25,7 +25,7 @@ def handleQuery(query):
             if win.desktop == "-1":
                 continue
 
-            win_instance, win_class = win.wm_class.replace(' ', '-').split('.')
+            win_instance, win_class = win.wm_class.replace(' ', '-').rsplit('.', 1)
             matches = [
                 win_instance.lower(),
                 win_class.lower(),


### PR DESCRIPTION
I noticed that Window Switcher results go missing if there is an open window with WM_CLASS name containing multiple `.` chars.

E.g. On my system, Ubuntu Software center is reported as follows

```
➜  ~ wmctrl -l -x | grep Software
0x01a00009  0 org.gnome.Software.Org.gnome.Software  quasar Ubuntu Software
```

That WM_CLASS causes the extension to barf
```
09:24:44 [warn:python.modulev1] [window_switcher] ValueError: too many values to unpack (expected 2)

At:
  /home/lex/.local/share/albert/org.albert.extension.python/modules/window_switcher/__init__.py(28): handleQuery
.
```

This patch resolves the issue, by just splitting the string once, on the final `.` char.