### PR TITLE
[window_switcher] Fix WM_CLASS with an unexpected number of parts

### DIFF
--- a/window_switcher/__init__.py
+++ b/window_switcher/__init__.py
@@ -25,7 +25,19 @@ def handleQuery(query):
             if win.desktop == "-1":
                 continue
 
-            win_instance, win_class = win.wm_class.replace(' ', '-').split('.')
+            # Usually the WM_CLASS output from wmctrl consists of instance and
+            # class name separated by a dot. In some cases, the instance and
+            # class name can dontain a dot themselves (e.g. org.gnome.Nautilus).
+            # In that case we assume that both parts have the same number of
+            # pieces and split them in the middle.
+            win_instance = win.wm_class
+            win_class = ""
+
+            wm_class_pieces = win.wm_class.replace(' ', '-').split('.')
+            if len(wm_class_pieces) % 2 == 0:
+                win_insthutance = '.'.join(wm_class_pieces[:len(wm_class_pieces) // 2])
+                win_class = '.'.join(wm_class_pieces[len(wm_class_pieces) // 2:])
+
             matches = [
                 win_instance.lower(),
                 win_class.lower(),


### PR DESCRIPTION
Closes albertlauncher/albert#967.

Usually the WM_CLASS printed by wmctrl has two parts (instance and class
name), separated by a dot. There are cases where this is not true:

* Chrome's picture-in-picture window shows a WM_CLASS of N/A (see
  albertlauncher/albert#967).
* Nautilus / Gnome Files on Ubuntu 20.04 shows a WM_CLASS value of
  'org.gnome.Nautilus.Org.gnome.Nautilus', indicating the instance name
  'org.gnome.Nautilus' with the class 'Org.gnome.Nautilus'.

Both cases previously lead to a ValueError due to the unexpected number
of parts after the split.

We now handle the second case by splitting the list of dot-separated
parts in the middle, assuming both pieces have the same number of parts.
As a fallback, we use the whole WM_CLASS as the instance name, which
should also cover the case of the Chrome window.