### PR TITLE
Add vscode projects plugin as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,6 @@
 [submodule "jetbrains_projects"]
 	path = jetbrains_projects
 	url = https://github.com/mqus/jetbrains-albert-plugin.git
+[submodule "vscode_projects"]
+	path = vscode_projects
+	url = https://github.com/Sharsie/albertlauncher-vscode-projects


### PR DESCRIPTION
Following in the steps of @mqus , this PR will add Visual Studio Code autosuggestion support as a submodule to albert launcher python plugins.

Since I was meddling with the jetbrains plugin in the past, I took the liberty to make something similar for VS Code.

Supports
- autosuggestions for recently opened paths as seen in the VS Code menu dialog - builds on top of the more verbose menu entries
- Projects managed by [Project Manager](https://marketplace.visualstudio.com/items?itemName=alefragnani.project-manager) plugin

This is an extension to https://github.com/albertlauncher/python/pull/114 