### PR TITLE
copyq: fix item icons by resolving item id clash

### DIFF
--- a/copyq/__init__.py
+++ b/copyq/__init__.py
@@ -3,10 +3,10 @@
 import json
 import subprocess
 
-from albert import *
+from albert import Action, Item, Query, QueryHandler, runDetachedProcess
 
 md_iid = "0.5"
-md_version = "1.2"
+md_version = "1.3"
 md_name = "CopyQ"
 md_description = "Access CopyQ clipboard"
 md_license = "BSD-2-Clause"
@@ -82,7 +82,7 @@ class Plugin(QueryHandler):
             )
             items.append(
                 Item(
-                    id=md_id,
+                    id=f"{md_id}-item",
                     icon=["xdg:copyq"],
                     text=text,
                     subtext="%s: %s" % (row, ", ".join(json_obj["mimetypes"])),


### PR DESCRIPTION
I think the item id `copyq` clashes with the id of the item produced by the plugin extension for the copyq plugin.
Anyway, the copyq items were using the Python icon instead of the CopyQ icon.
Changing the id of result items seems to fix that.