### PR TITLE
fix api_test delay option

### DIFF
--- a/api_test/__init__.py
+++ b/api_test/__init__.py
@@ -26,7 +26,7 @@ md_maintainers = "@manuelschneid3r"
 
 class Plugin(QueryHandler):
     def id(self):
-        return "someid";
+        return "test";
 
     def name(self):
         return "somename";
@@ -51,10 +51,10 @@ class Plugin(QueryHandler):
 
         if query.string.startswith("delay"):
             sleep(2)
-            return Item(id=__title__,
+            return query.add(Item(id=md_id,
                         text="Delayed test item",
                         subtext="Query string: %s" % query.string,
-                        icons=os.path.dirname(__file__)+"/plugin.svg")
+                        icon=[os.path.dirname(__file__)+"/plugin.svg"]))
 
         if query.string.startswith("throw"):
             raise ValueError('EXPLICITLY REQUESTED TEST EXCEPTION!')


### PR DESCRIPTION
- `test` as trigger makes more sense for me
- since 0.5 query.add is necessary (?)
- icon should be a list and not icon**s**

