### PR TITLE
Add wireguard to VPN connection types

### DIFF
--- a/vpn/__init__.py
+++ b/vpn/__init__.py
@@ -40,7 +40,7 @@ class Plugin(QueryHandler):
         )
         for conStr in consStr.splitlines():
             con = conStr.split(':')
-            if con[2] == 'vpn':
+            if con[2] in ['vpn', 'wireguard']:
                 yield self.VPNConnection(name=con[0], connected=con[3] != '')
 
 


### PR DESCRIPTION
This is just a small change to allow the `vpn` plugin to also show WireGuard connections in the list. WireGuard is also a VPN but NetworkManager uses a different type for it (`wireguard` instead of `vpn`).