### PR TITLE
[python_eval] Fix type of result in item subtext

### DIFF
--- a/python_eval/__init__.py
+++ b/python_eval/__init__.py
@@ -7,7 +7,7 @@ from math import *
 import os
 
 md_iid = "0.5"
-md_version = "1.2"
+md_version = "1.3"
 md_name = "Python Eval"
 md_description = "Evaluate Python code"
 md_license = "BSD-3"
@@ -39,18 +39,20 @@ class Plugin(QueryHandler):
         stripped = query.string.strip()
         if stripped:
             try:
-                result = str(eval(stripped))
+                result = eval(stripped)
             except Exception as ex:
-                result = str(ex)
+                result = ex
+
+            result_str = str(result)
 
             query.add(Item(
                 id=md_id,
-                text=str(result),
+                text=result_str,
                 subtext=type(result).__name__,
-                completion=query.trigger + result,
+                completion=query.trigger + result_str,
                 icon=[self.iconPath],
                 actions = [
-                    Action("copy", "Copy result to clipboard", lambda r=str(result): setClipboardText(r)),
-                    Action("exec", "Execute python code", lambda r=str(result): exec(stripped)),
+                    Action("copy", "Copy result to clipboard", lambda r=result_str: setClipboardText(r)),
+                    Action("exec", "Execute python code", lambda r=result_str: exec(stripped)),
                 ]
             ))


### PR DESCRIPTION
The subtext of items produced by the python eval extension, which is supposed to contain the type of the result of evaluating the python expression, would always incorrectly show `str`.

I fixed this by delaying the conversion of the result to a string.