### PR TITLE
fix(emoji): set correct import for iid 1.0

### DIFF
--- a/emoji/__init__.py
+++ b/emoji/__init__.py
@@ -10,11 +10,10 @@ import subprocess
 from concurrent.futures import ThreadPoolExecutor
 from itertools import islice
 from pathlib import Path
-
-from albert import Action, Item, QueryHandler, cacheLocation, setClipboardText
+from albert import *
 
 md_iid = '1.0'
-md_version = "1.1"
+md_version = "1.2"
 md_name = "Emoji Picker"
 md_description = "Find emojis by name"
 md_license = "GPL-3.0"


### PR DESCRIPTION
Since the change to iid 1.0, `TriggerQueryHandler` replace `QueryHandler`, which this plugin was imported.