### PR TITLE
fix(emoji): call cacheLocation as method of self

### DIFF
--- a/emoji/__init__.py
+++ b/emoji/__init__.py
@@ -64,7 +64,7 @@ class Plugin(TriggerQueryHandler):
         return "<emoji name>"
 
     def initialize(self):
-        self.icon_dir_path = Path(cacheLocation())
+        self.icon_dir_path = Path(self.cacheLocation())
 
         line_re = re.compile(
             r"""


### PR DESCRIPTION
Fixes https://github.com/albertlauncher/python/issues/179.

I was getting annoyed by the issue so I decided to look into it, turns out it was a trivial fix. :sweat_smile: 

It works now, to the extent that I can find emojis and copy them to clipboard. Let me know if further testing is needed.

![image](https://github.com/albertlauncher/python/assets/5107795/67f36882-aab4-4997-b22c-9d3a9a07a44c)
