### PR TITLE
feat(pass): follow symlinks

### DIFF
--- a/pass/__init__.py
+++ b/pass/__init__.py
@@ -76,7 +76,7 @@ class Plugin(PluginInstance, TriggerQueryHandler):
 
     def getPasswords(self):
         passwords = []
-        for root, dirnames, filenames in os.walk(PASS_DIR):
+        for root, dirnames, filenames in os.walk(PASS_DIR, followlinks=True):
             for filename in fnmatch.filter(filenames, "*.gpg"):
                 passwords.append(
                     os.path.join(root, filename.replace(".gpg", "")).replace(PASS_DIR, "")


### PR DESCRIPTION
Enable following symlinks to be able to use directory aliases or pass git repos added to .password-store via symlinks.