### PR TITLE
[jetbrains_projects] Fix that plugin returned no results if recentProjects.xml is missing

### DIFF
--- a/jetbrains_projects/__init__.py
+++ b/jetbrains_projects/__init__.py
@@ -78,7 +78,7 @@ class Editor:
                         Project(name=Path(project_path).name, path=project_path, last_opened=int(last_opened))
                     )
             return projects
-        except ElementTree.ParseError:
+        except (ElementTree.ParseError, FileNotFoundError):
             return []
 
 


### PR DESCRIPTION
If an IDE is installed, but there is no recentProjects.xml, `ElementTree.parse` threw an uncaught FileNotFoundError, causing a critical albert error.

```
Invoked with: 
16:05:01 [crit:python] FileNotFoundError: [Errno 2] No such file or directory: '/home/<redacted>/.config/JetBrains/Rider2021.3/options/recentProjects.xml'

At:
  /usr/lib/python3.11/xml/etree/ElementTree.py(569): parse
  /usr/lib/python3.11/xml/etree/ElementTree.py(1218): parse
  /usr/share/albert/python/plugins/jetbrains_projects/__init__.py(81): _parse_recent_projects
  /usr/share/albert/python/plugins/jetbrains_projects/__init__.py(62): list_projects
  /usr/share/albert/python/plugins/jetbrains_projects/__init__.py(164): handleTriggerQuery
