### PR TITLE
[mathematica_eval] Fixed missing import

### DIFF
--- a/mathematica_eval/__init__.py
+++ b/mathematica_eval/__init__.py
@@ -4,8 +4,7 @@ import subprocess
 from tempfile import NamedTemporaryFile
 from threading import Lock
 
-from albert import (Action, Item, TriggerQuery, TriggerQueryHandler,
-                    setClipboardText)
+from albert import *
 
 md_iid = "2.0"
 md_version = "1.1"


### PR DESCRIPTION
This is just a quick fix for mathematica_eval, since last update it seems that PluginInstance is missing from imports.
I changed to importing all albert.