### PR TITLE
Add pycharm-professional to binary list

### DIFF
--- a/jetbrains_projects/__init__.py
+++ b/jetbrains_projects/__init__.py
@@ -167,7 +167,7 @@ class Plugin(PluginInstance, TriggerQueryHandler):
                 name="PyCharm",
                 icon=plugin_dir / "icons" / "pycharm.svg",
                 config_dir_prefix="JetBrains/PyCharm",
-                binaries=["charm", "pycharm", "pycharm-eap"]),
+                binaries=["charm", "pycharm", "pycharm-eap", "pycharm-professional"]),
             Editor(
                 name="Rider",
                 icon=plugin_dir / "icons" / "rider.svg",


### PR DESCRIPTION
Hi! I noticed that pycharm projects were not popping up for me, so this seems to be the fix. For reference, this is happening on archlinux with the [pycharm-professional](https://aur.archlinux.org/packages/pycharm-professional) package from AUR.

Thank you for maintaining the plugin!