### PR TITLE
Entries caching for Bitwarden plugin

### DIFF
--- a/bitwarden/__init__.py
+++ b/bitwarden/__init__.py
@@ -9,7 +9,7 @@ from subprocess import CalledProcessError, run
 from albert import *
 
 md_iid = "3.0"
-md_version = "3.0"
+md_version = "3.1"
 md_name = "Bitwarden"
 md_description = "'rbw' wrapper extension"
 md_license = "MIT"


### PR DESCRIPTION
This implements what was requested on [this discussion](https://github.com/orgs/albertlauncher/discussions/1512)

The output of `rbw list` will be cached, by default, for 5 minutes or until sync action is called. This time is configurable 

![image](https://github.com/user-attachments/assets/b5adb133-d54d-454d-87b5-176a24967e3a)
