### PR TITLE
[bitwarden] Fix freeze when triggering bitwarden

### DIFF
--- a/bitwarden/__init__.py
+++ b/bitwarden/__init__.py
@@ -68,8 +68,9 @@ class Plugin(PluginInstance, TriggerQueryHandler):
         ]
 
     def handleTriggerQuery(self, query):
+        results = []
         if query.string.strip().lower() == "sync":
-            query.add(
+            results.append(
                 StandardItem(
                     id="sync",
                     text="Sync Bitwarden Vault",
@@ -85,7 +86,7 @@ class Plugin(PluginInstance, TriggerQueryHandler):
             )
 
         for p in self._filter_items(query):
-            query.add(
+            results.append(
                 StandardItem(
                     id=p["id"],
                     text=p["path"],
@@ -117,6 +118,8 @@ class Plugin(PluginInstance, TriggerQueryHandler):
                     ],
                 )
             )
+
+        query.add(results)
 
     def _get_items(self):
         not_first_time = self._cached_items is not None


### PR DESCRIPTION
A freeze can be observed when triggering the bitwarden plugin. This seems to occur the second time `query.add` is called. To fix this issue the same logic as the `kill` plugin is used: Add all items to a local array before finally adding this using `query.add`

This fixes https://github.com/albertlauncher/python/issues/215