### PR TITLE
Fix syncthing plugin

### DIFF
--- a/syncthing/__init__.py
+++ b/syncthing/__init__.py
@@ -41,7 +41,6 @@ class Plugin(PluginInstance, GlobalQueryHandler):
     @property
     def api_key(self) -> str:
         return self._api_key
-        # return '1234'
 
     @api_key.setter
     def api_key(self, value: str):


### PR DESCRIPTION
Syncthing wasn't working properly. Was throwing errors about st not being defined any time the user types in albert, and the error `[crit:albert.python] Unable to cast Python instance of type <class 'NoneType'> to C++ type 'QString'` when opening settings, displaying a blank window instead of the api key field. This PR:

- Adds handling to make sure the api key is never None type, fixing the settings issue
- Adds handling for missing and invalid api keys
    - Shows distinct messages for each scenarios

**Screenshots**
![image](https://github.com/user-attachments/assets/3f55eda7-95b9-4a10-9ff5-a8194b05af52)
Valid api key

![image](https://github.com/user-attachments/assets/0f8bdf56-6779-47b6-b6da-8446acb74d25)
Invalid api key

![image](https://github.com/user-attachments/assets/a7cb5c91-0267-4234-875f-4a0ed81b7043)
No api key