### PR TITLE
[vscode_projects:1.11] Updates recents search to use latest vscode configuration, performance improvements

### DIFF
--- a/vscode_projects/__init__.py
+++ b/vscode_projects/__init__.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass
 from albert import *
 
 md_iid = "3.0"
-md_version = "1.9"
+md_version = "1.10"
 md_name = "VSCode projects"
 md_description = "Open VSCode projects"
 md_url = "https://github.com/albertlauncher/python/tree/master/vscode_projects"
@@ -103,7 +103,7 @@ class Plugin(PluginInstance, TriggerQueryHandler):
             warning(
                 "Project Manager search was enabled, but configuration file was not found")
             notif = Notification(
-                title=f"{self.name}",
+                title=self.name,
                 text=f"Configuration file was not found for the Project Manager extension. Please make sure the extension is installed."
             )
             notif.send()
@@ -359,7 +359,7 @@ Usecase with single VSCode instance - To reuse the VSCode window instead of open
             text=project.displayName,
             subtext=f"{subtext}{project.path}",
             iconUrls=self.iconUrls,
-            inputActionText=f"{query.trigger}{project.displayName}",
+            inputActionText=project.displayName,
             actions=actions,
         )
 


### PR DESCRIPTION
This PR replaces searching through legacy `json` vscode configuration files by querying sqlite database. Recents are only stored and updated in the db in the latest versions.

It also improves documentation and introduces some performance optimizations and error handling.

Removes support for multiple paths per configuration and only uses a single path to read configuration from. Previously, this was implemented to support older versions of vscode, but sqlite has completely replaced this a while ago so I've cleaned up the code that deals with the multi-config feature.

It also enables searching through recents when only query trigger is supplied with empty query. Previously typing a query trigger yielded no results. I believe this improves UX by offering the latest entries immediately.

Comes bundled with https://github.com/albertlauncher/python/pull/224 - I honestly did not know how to version these properly without having to update one PR after the other gets merged. So ideally https://github.com/albertlauncher/python/pull/224 should be merged first.

